### PR TITLE
Add LSAs with all kind of lane types to data basis of SG selector

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -38,7 +38,7 @@ COPY . /code
 
 # Define the FROST API from which we will fetch the things
 ARG FROST_API=https://tld.iot.hamburg.de/v1.1
-ARG FROST_FILTER=%28%28Datastreams%2Fproperties%2FserviceName+eq+%27HH_STA_traffic_lights%27%29+and+%28%28properties%2FlaneType+eq+%27Radfahrer%27%29+or+%28%28properties%2FlaneType+eq+%27KFZ%2FRadfahrer%27%29+or+%28%28properties%2FlaneType+eq+%27Fußgänger%2FRadfahrer%27%29+or+%28%28properties%2FlaneType+eq+%27Bus%2FRadfahrer%27%29+or+%28properties%2FlaneType+eq+%27KFZ%2FBus%2FRadfahrer%27%29%29%29%29%29%29
+ARG FROST_FILTER=%28Datastreams%2Fproperties%2FserviceName%20eq%20%27HH_STA_traffic_lights%27%29
 
 ENV FROST_API=$FROST_API
 ENV FROST_FILTER=$FROST_FILTER

--- a/backend/backend/routing/matching/__init__.py
+++ b/backend/backend/routing/matching/__init__.py
@@ -43,7 +43,8 @@ def get_matches(route: LineString, matchers: List[RouteMatcher]) -> Iterable[LSA
     """
     Return all LSA's that match the route.
     """
-    matched_lsas = LSA.objects.all()
+    # Only consider LSA's that are also for cyclists
+    matched_lsas = LSA.objects.filter(lsametadata__lane_type__icontains="Radfahrer")
     for matcher in matchers:
         matched_lsas, _ = matcher.matches(matched_lsas, route)
     return matched_lsas


### PR DESCRIPTION
Corresponding ticket: https://trello.com/c/GTpyAACT

Current state:
- With this change we end up with 19526 LSAs in total. 5297 of that are also for cyclists. 
- When running the `load_crossings` and `sync_crossings`commands we end up with the following:
```
Finished syncing 1867 crossings.
Created 120 crossings.
886 Crossings are connected.
981 Crossings are not connected.
```

Before it was like that:
```
Finished syncing 1825 crossings.
Created 78 crossings.
762 Crossings are connected.
1063 Crossings are not connected.
```

-> Thus, it can be assumed that the measure is effective in having fewer false disconnected crossings along the route. Although its only a change of 82 LSAs.